### PR TITLE
Made progress bar wider

### DIFF
--- a/src/containers/progress/index.js
+++ b/src/containers/progress/index.js
@@ -91,7 +91,7 @@ class ProgressDisplay extends Component {
         <h1 className="white header__progress" onClick={this.clickMetric}>
           {displayMetric} <span>Progress</span>
         </h1>
-        <div style={{ height: '8%', width: '80%' }} className="progress__bar">
+        <div style={{ height: '8%', width: '100%' }} className="progress__bar">
           <Line
             percent={this.props.progress.percent}
             strokeWidth={1}


### PR DESCRIPTION
Changed the bar width from 80% to 100%. Here's what it looks like:
![Wider progress bar](https://user-images.githubusercontent.com/14034891/48247055-fd660c80-e445-11e8-9b95-975546c087db.png)
