### PR TITLE
Added more spacing around the progress bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,7 +106,7 @@ span, label, div, input {
 }
 
 .progress__bar {
-  margin: 1%;
+  margin: 3%;
   text-shadow: rgba(0,0,0,.1) 2px 5px 10px;
 }
 


### PR DESCRIPTION
Changed the margin from 1% to 3%. Here's what it looks like:
![More spacing around the progress bar](https://user-images.githubusercontent.com/14034891/48247208-9563f600-e446-11e8-84b5-904f784fdc92.png)
